### PR TITLE
Serve profile picture

### DIFF
--- a/app/routing.go
+++ b/app/routing.go
@@ -19,6 +19,7 @@ func addRoutes() {
 	router.PATCH("/users/:user_id/change_password", users.UpdateUserPassword)
 	router.POST("users/:user_id/upload_profile_pic", users.UploadUserProfilePic)
 	router.POST("/users/login", users.Login)
+	router.GET("/users/pics/:pic_hash", users.GetUSerProfilePicture)
 
 	// Swagger Documentation
 	opts := middleware.RedocOpts{SpecURL: "./swagger.yml", Title: "Moku-Moku-Users"}

--- a/controllers/users/UserController.go
+++ b/controllers/users/UserController.go
@@ -303,3 +303,13 @@ func Login(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, user.Marshall(c.GetHeader("X-Public") == "true"))
 }
+
+func GetUSerProfilePicture(c *gin.Context) {
+	picHash := c.Param("pic_hash")
+	if picHash == "" {
+		c.JSON(http.StatusNotFound, "could not find the specified profile picture")
+		return
+	}
+	basePath := "./MokuMoku/profile_pics/"
+	c.File(basePath + picHash)
+}

--- a/controllers/users/UserController.go
+++ b/controllers/users/UserController.go
@@ -259,22 +259,23 @@ func UploadUserProfilePic(c *gin.Context) {
 		return
 	}
 
-	name := file.Filename
-	hashedName := sha256.Sum256([]byte(name))
+	// Split the between file name and file extension
+	name := strings.Split(file.Filename, ".")
+	hashedName := sha256.Sum256([]byte(name[0]))
 	hashedNameString := hex.EncodeToString(hashedName[:])
 
 	//map to user model
 	var user users.User
 	user.Id = userId
-	user.ProfilePic = hashedNameString
+	user.ProfilePic = hashedNameString + "." + name[1]
 
 	//write file to basePath
-	basePath := "/MokuMoku/profile_pics/"
+	basePath := "./MokuMoku/profile_pics/"
 	if _, err := os.Stat(basePath); os.IsNotExist(err) {
 		//create directory
 		os.MkdirAll(basePath, 0700)
 	}
-	saveErr := c.SaveUploadedFile(file, basePath+hashedNameString+".png")
+	saveErr := c.SaveUploadedFile(file, basePath+hashedNameString+"."+name[1])
 	if saveErr != nil {
 		c.JSON(http.StatusInternalServerError, errors.InternalServerError("file could not be saved"))
 	}

--- a/controllers/users/UserController.go
+++ b/controllers/users/UserController.go
@@ -254,7 +254,7 @@ func UploadUserProfilePic(c *gin.Context) {
 	}
 
 	fileType := file.Header.Get("Content-Type")
-	if fileType != "image/jpeg" {
+	if fileType != "image/jpeg" && fileType != "image/png" {
 		c.JSON(http.StatusBadRequest, errors.BadRequest("file must be of type image"))
 		return
 	}

--- a/controllers/users/UserController.go
+++ b/controllers/users/UserController.go
@@ -15,6 +15,8 @@ import (
 	"github.com/mokumoku-lovers/moku-moku-oauth-go/oauth"
 )
 
+const BASE_PATH = "./MokuMoku/profile_pics/"
+
 func GetUser(c *gin.Context) {
 	authErr := oauth.AuthenticateRequest(c.Request)
 	if authErr != nil {
@@ -270,12 +272,11 @@ func UploadUserProfilePic(c *gin.Context) {
 	user.ProfilePic = hashedNameString + "." + name[1]
 
 	//write file to basePath
-	basePath := "./MokuMoku/profile_pics/"
-	if _, err := os.Stat(basePath); os.IsNotExist(err) {
+	if _, err := os.Stat(BASE_PATH); os.IsNotExist(err) {
 		//create directory
-		os.MkdirAll(basePath, 0700)
+		os.MkdirAll(BASE_PATH, 0700)
 	}
-	saveErr := c.SaveUploadedFile(file, basePath+hashedNameString+"."+name[1])
+	saveErr := c.SaveUploadedFile(file, BASE_PATH+hashedNameString+"."+name[1])
 	if saveErr != nil {
 		c.JSON(http.StatusInternalServerError, errors.InternalServerError("file could not be saved"))
 	}
@@ -310,6 +311,5 @@ func GetUSerProfilePicture(c *gin.Context) {
 		c.JSON(http.StatusNotFound, "could not find the specified profile picture")
 		return
 	}
-	basePath := "./MokuMoku/profile_pics/"
-	c.File(basePath + picHash)
+	c.File(BASE_PATH + picHash)
 }

--- a/swagger.yml
+++ b/swagger.yml
@@ -247,6 +247,29 @@ paths:
           description: Error
           schema:
             $ref: "#/definitions/RestErr"
+  /users/pics/{pic_hash}:
+    parameters:
+      - in: path
+        type: string
+        format: string
+        name: pic_hash
+        required: true
+        description: The relative image path (profile_picture) from the User DTO
+      - $ref: "#/parameters/access_token"
+
+    get:
+      tags:
+        - user
+      produces:
+        - image/png
+        - image/jpeg
+      operationId: getProfilePic
+      description: Retrieve a user profile picture
+      responses:
+        '200':
+          description: Profile picture retrieved correctly
+        '404':
+          description: Profile picture not found
   /users/{user_id}/change_password:
     parameters:
       - $ref: "#/parameters/user_id"


### PR DESCRIPTION
The service now supports PNG images too and stores the image with the file extension.
These are served by the API on the `/users/pics/:pic_hash` route